### PR TITLE
Fix build fail & all warnings on Xcode 7+

### DIFF
--- a/GGFullscreenImageViewController.xcodeproj/project.pbxproj
+++ b/GGFullscreenImageViewController.xcodeproj/project.pbxproj
@@ -211,7 +211,7 @@
 			name = GGFullscreenImageViewControllerTests;
 			productName = GGFullscreenImageViewControllerTests;
 			productReference = 72E4F78F17154F9600644B6C /* GGFullscreenImageViewControllerTests.octest */;
-			productType = "com.apple.product-type.bundle";
+			productType = "com.apple.product-type.bundle.ocunit-test";
 		};
 /* End PBXNativeTarget section */
 
@@ -219,7 +219,8 @@
 		72E4F76117154F9600644B6C /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0460;
+				LastTestingUpgradeCheck = 0730;
+				LastUpgradeCheck = 0730;
 				ORGANIZATIONNAME = "John Wu";
 			};
 			buildConfigurationList = 72E4F76417154F9600644B6C /* Build configuration list for PBXProject "GGFullscreenImageViewController" */;
@@ -354,6 +355,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -402,6 +404,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "GGFullscreenImageViewController/GGFullscreenImageViewController-Prefix.pch";
 				INFOPLIST_FILE = "GGFullscreenImageViewController/GGFullscreenImageViewController-Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.tfm.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
 			};
@@ -413,6 +416,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "GGFullscreenImageViewController/GGFullscreenImageViewController-Prefix.pch";
 				INFOPLIST_FILE = "GGFullscreenImageViewController/GGFullscreenImageViewController-Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.tfm.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
 			};
@@ -429,6 +433,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "GGFullscreenImageViewController/GGFullscreenImageViewController-Prefix.pch";
 				INFOPLIST_FILE = "GGFullscreenImageViewControllerTests/GGFullscreenImageViewControllerTests-Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.tfm.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUNDLE_LOADER)";
 				WRAPPER_EXTENSION = octest;
@@ -446,6 +451,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "GGFullscreenImageViewController/GGFullscreenImageViewController-Prefix.pch";
 				INFOPLIST_FILE = "GGFullscreenImageViewControllerTests/GGFullscreenImageViewControllerTests-Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.tfm.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUNDLE_LOADER)";
 				WRAPPER_EXTENSION = octest;

--- a/GGFullscreenImageViewController/GGFullScreenImageViewController.m
+++ b/GGFullscreenImageViewController/GGFullScreenImageViewController.m
@@ -26,6 +26,7 @@ static inline GGOrientation convertOrientation(UIInterfaceOrientation orientatio
             return GGOrientationLandscapeRight;
             break;
         default:
+          return GGOrientationPortrait;
             break;
     }
 }
@@ -284,7 +285,7 @@ static inline NSInteger RadianDifference(UIInterfaceOrientation from, UIInterfac
 
 }
 
-- (NSUInteger) supportedInterfaceOrientations {
+- (UIInterfaceOrientationMask) supportedInterfaceOrientations {
     return self.supportedOrientations;
 }
 

--- a/GGFullscreenImageViewController/GGFullscreenImageViewController-Info.plist
+++ b/GGFullscreenImageViewController/GGFullscreenImageViewController-Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.tfm.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/GGFullscreenImageViewController/ViewController.m
+++ b/GGFullscreenImageViewController/ViewController.m
@@ -38,7 +38,7 @@
     // Dispose of any resources that can be recreated.
 }
 
-- (NSUInteger) supportedInterfaceOrientations {
+- (UIInterfaceOrientationMask) supportedInterfaceOrientations {
     return UIInterfaceOrientationMaskPortrait;
 }
 

--- a/GGFullscreenImageViewControllerTests/GGFullscreenImageViewControllerTests-Info.plist
+++ b/GGFullscreenImageViewControllerTests/GGFullscreenImageViewControllerTests-Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.tfm.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundlePackageType</key>


### PR DESCRIPTION
The project didn't build when attempting to compile it on Xcode 7.3.1. This was caused by the deprecated OCTest that was replaced by XCTest. Xcode automatically suggested migrating to XCTest and that fixed the build fail issue.
Moreover, there was 3 warnings that got fixed.
